### PR TITLE
Check dgl version for adj

### DIFF
--- a/Node/preprocess_node_data.py
+++ b/Node/preprocess_node_data.py
@@ -124,7 +124,8 @@ def load_data(dataset_str):
 
 
 def eig_dgl_adj_sparse(g, sm=0, lm=0):
-    A = g.adj(scipy_fmt='csr')
+    adj_fn = g.adj if version.parse(dgl.__version__) < version.parse('1.1') else g.adj_external
+    A = adj_fn(scipy_fmt='csr')
     deg = np.array(A.sum(axis=0)).flatten()
     D_ = sp.sparse.diags(deg ** -0.5)
 


### PR DESCRIPTION
It seems like `dgl.adj` is deprecated after v1.1 and replaced with `dgl.adj_external`.